### PR TITLE
HUB-2741 Blamda changes to copy .js file inside the lambda folder

### DIFF
--- a/blambda/utils/lambda_manifest.py
+++ b/blambda/utils/lambda_manifest.py
@@ -152,7 +152,7 @@ class LambdaManifest(object):
             else:
                 if dest_dir != self.basedir:
                     src = (self.basedir / source_spec).resolve()
-                    if src.suffix == '.coffee':
+                    if src.suffix == '.coffee' or src.suffix == '.js':
                         yield src, dest_dir / self.short_name / source_spec
                     else:
                         yield src, dest_dir / source_spec

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(name='blambda',
-      version='0.3.18',
+      version='0.3.19',
       description='Balihoo Command Line Tools for AWS Lambda function management',
       author='Balihoo Developers',
       author_email='devall@balihoo.com',


### PR DESCRIPTION
1. I did changes in the lambda_manifest.py file, which is used to putting .coffee file inside the lambda folder. I added the OR condition to put the .js file in the same folder.

2. Also updated the version number.

**NOTES:**
Tested changes locally by installing the specific blamda GIT commit, by using the following PIP command.
pip install git+https://github.com/balihoo/blambda.git@26c09606a1660e6f6f9e714ab1b9b569601d48e3

I also tested my changes locally, by creating a sample Lambda function in the JS file, and generates the zip file using `blamda deploy <LAMDA_FOLDER_NAME>` command, it generates the folder and put the JS Lambda function file inside the folder. 

From my local machine, I am not able to deploy to AWS using blamda deploy command, it required some permission., which i am not able to figure out. But manually deploy the generated .zip file from the AWS Lambda UI, and tested the lambda function, and it is working as expected.